### PR TITLE
CSS: Fix - WP image margin

### DIFF
--- a/assets/scss/reset/_wordpress.scss
+++ b/assets/scss/reset/_wordpress.scss
@@ -8,12 +8,12 @@ to override any of the settings in this section, add your styling code in the cu
 
 .alignright {
 	float: right;
-	margin-right: 1rem;
+	margin-left: 1rem;
 }
 
 .alignleft {
 	float: left;
-	margin-left: 1rem;
+	margin-right: 1rem;
 }
 
 .aligncenter {


### PR DESCRIPTION
wp images alignment fix: 

When we have img.alignleft margin should be on the right and vice-versa for img.alignright.